### PR TITLE
fix: fix v6 create random wallet

### DIFF
--- a/zksync-ethers/index.js
+++ b/zksync-ethers/index.js
@@ -47,12 +47,10 @@ async function registerQuestUsingPaymaster() {
   // create zksync provider
   const provider = new Provider(zksyncRpcUrl);
   // generate random wallet
-  const wallet = Wallet.createRandom();
-  // connect wallet to provider
-  const connectedWallet = wallet.connect(provider);
+  const wallet = new Wallet(Wallet.createRandom().privateKey, provider, null);
 
   // register quest with newly generated wallet
-  await registerQuest(connectedWallet);
+  await registerQuest(wallet);
 }
 
 // Handler


### PR DESCRIPTION
The main issue is that we could not override `Wallet.createRandom()` in `v6` as we did in `v5`. So when you want to create random wallet you should do it like it's shown here.